### PR TITLE
fix: suppl_table_kill, PASS mmap-exit

### DIFF
--- a/vm/vm.c
+++ b/vm/vm.c
@@ -309,6 +309,13 @@ void supplemental_page_table_kill(struct supplemental_page_table *spt)
 {
 	/* TODO: Destroy all the supplemental_page_table hold by thread and
 	 * TODO: writeback all the modified contents to the storage. */
+	struct list_elem *soon_die_elem = list_begin(&thread_current()->mmap_list);
+		while (soon_die_elem != list_end(&thread_current()->mmap_list))
+		{
+			struct mmap_file *soon_die_file = list_entry(soon_die_elem, struct mmap_file, elem);
+			soon_die_elem = soon_die_elem->next;
+			munmap(soon_die_file->mapid);
+		}
 
 	hash_destroy(&spt->table, hash_destructor);
 }


### PR DESCRIPTION
mmap-write TC는 PASS지만, mmap-exit TC는 FAIL이였습니다.

문제해결 과정
1. 둘다 동일한 방식으로 (create-> open -> mmap)으로 파일을 작성한다는 것을 알게 되었습니다.
2. mmap-write TC에서는 munmap을 해주고 프로그램을 종료해주었습니다.
3. mmap-exit TC에서는 아무런 조치도 이루어지지 않았습니다.(exit되면서 프로세스 종료)
4. mmap-exit TC의 경우, child process에서의 변경사항(파일 작성)이 그대로 날아가 버렸기에 테스트가 실패되었습니다.
5.` exit()` 안의 `process_cleanup()`안의 `suppl_table_kill()`에서도 `munmap()`이 이루어 지도록 고쳐서 통과시켰습니다.
  5-1. (참고) process.c의 thread_exit()함수 내의 `#ifdef USERPROG` 가 작동을 안할 줄 알았는데 작동합니다.(난 안돌줄 알았음...)
  5-2. 아.. 리스트로 안만들면 절대로 munmap못하겠구나 라는 생각이 들었습니다.

<img width="213" alt="image" src="https://user-images.githubusercontent.com/63194662/206477724-d72f8bb5-766f-4a02-897a-8a1c75ff69e6.png">
