### PR TITLE
fix: syscall(mmap addr conditions), PASS mmap-kernel

### DIFF
--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -247,7 +247,6 @@ void syscall_handler(struct intr_frame *f UNUSED)
 		// argv[2]: int writable
 		// argv[3]: int fd
 		// argv[4]: off_t offset
-		check_address(f->R.rdi);
 		f->R.rax = mmap(f->R.rdi, f->R.rsi, f->R.rdx, f->R.r10, f->R.r8);
 		break;
 
@@ -538,6 +537,16 @@ void *mmap(void *addr, size_t length, int writable, int fd, off_t offset)
 	if (spt_find_page(&cur->spt, addr) == &addr)
 		return NULL;
 	if (file == NULL || file == STDIN || file == STDOUT)
+		return NULL;
+
+	/*for mmap-kernel validation*/
+	if (is_kernel_vaddr(addr))
+		return NULL;
+	if (addr > KERN_BASE + 10000000)
+		return NULL;
+	if (is_kernel_vaddr(addr + length))
+		return NULL;
+	if (addr + length == NULL)
 		return NULL;
 
 	return do_mmap(addr, length, writable, file, offset);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/63194662/206652486-9cac0eb9-70d5-4a60-8d11-5d5e429ea215.png)

결국 아래와 같은 이상한 주소값에 mmap하면 fail내줄 수 있는지에 대한 테스트입니다. 이에따라 경계🚧조건을 추가했습니다

```c
  kernel = (void *) 0x8004000000;
  mmap (kernel, 4096, 0, handle, 0)

  kernel = (void *) 0xfffffffffffff000;
  mmap (kernel, 0x2000, 0, handle, 0) 

  kernel = (void *) 0x8004000000 - 0x1000;
  mmap (kernel, -0x8004000000 + 0x1000, 0, handle, 0) 
```