### PR TITLE
fix : mmap-over

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "files.associations": {
+        "*.html": "html",
         "random.h": "c",
         "process.h": "c",
         "intr-stubs.h": "c",
@@ -32,7 +33,10 @@
         "mmu.h": "c",
         "anon.h": "c",
         "main.h": "c",
-        "disk.h": "c"
+        "disk.h": "c",
+        "loader.h": "c",
+        "bitmap.h": "c",
+        "page_cache.h": "c"
     },
     "C_Cpp.errorSquiggles": "Disabled"
 }

--- a/include/vm/anon.h
+++ b/include/vm/anon.h
@@ -7,7 +7,7 @@ enum vm_type;
 
 struct anon_page // simons added
 {
-    int test;
+    int swap_slot_no;
 };
 
 void vm_anon_init(void);

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -58,6 +58,9 @@ struct page
 	/* mapped page */
 	struct list_elem mapped_elem;
 
+	/* For Project 3 : Swapping in & out */
+	size_t swap_slot_number; /* swap_slot number*/
+
 	/* Per-type data are binded into the union.
 	 * Each function automatically detects the current union */
 	union
@@ -69,6 +72,8 @@ struct page
 		struct page_cache page_cache;
 #endif
 	};
+
+	
 };
 
 /* The representation of "frame" */

--- a/userprog/exception.c
+++ b/userprog/exception.c
@@ -133,6 +133,7 @@ page_fault(struct intr_frame *f)
 
 	fault_addr = (void *)rcr2();
 
+
 	/* Turn interrupts back on (they were only off so that we could
 	   be assured of reading CR2 before it changed). */
 	intr_enable();
@@ -145,7 +146,6 @@ page_fault(struct intr_frame *f)
 	/* For project 3 and later. */
 	if (vm_try_handle_fault(f, fault_addr, user, write, not_present))
 		return;
-	// printf("========vm_try_hand_fault\n");
 #endif
 
 	/* Count page faults. */

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -342,6 +342,7 @@ error:
 void argument_stack(int argc, char **argv, struct intr_frame *_if)
 {
 	// argument를 역순으로 stack에 push
+	// printf("WHAT IS _if->rsp 11 : %p\n", _if->rsp); 
 	for (int i = argc - 1; i > -1; i--)
 	{
 		size_t len = strlen(argv[i]) + 1; // '\0'을 포함해야하므로 +1
@@ -373,6 +374,7 @@ void argument_stack(int argc, char **argv, struct intr_frame *_if)
 	// rdi(첫번째 인자 register)와 rsi(두번째 인자 register)에 argc와 argv 삽입
 	_if->R.rdi = argc;
 	_if->R.rsi = _if->rsp + 8;
+
 
 	thread_current()->user_rsp = _if->rsp;
 }

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -536,7 +536,7 @@ void *mmap(void *addr, size_t length, int writable, int fd, off_t offset)
 		return NULL;
 	if ((int)addr % PGSIZE != 0 || offset % PGSIZE != 0)
 		return NULL;
-	if (spt_find_page(&cur->spt, addr) == &addr)
+	if (spt_find_page(&cur->spt, addr))
 		return NULL;
 	if (file == NULL || file == STDIN || file == STDOUT)
 		return NULL;

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -111,9 +111,7 @@ void check_valid_buffer(void *buffer, unsigned size, void *rsp, bool to_write)
 		// to_write : 버퍼(= 페이지)에 대한 쓰기, 읽기 접근 
 		if (to_write == true && page->writable == false)
 			exit(-1);
-	}
-
-	
+	}	
 }
 
 

--- a/vm/anon.c
+++ b/vm/anon.c
@@ -2,6 +2,9 @@
 
 #include "vm/vm.h"
 #include "devices/disk.h"
+#include "lib/kernel/bitmap.h"
+#include "threads/vaddr.h"
+#include "threads/mmu.h"
 
 /* DO NOT MODIFY BELOW LINE */
 static struct disk *swap_disk;
@@ -17,11 +20,20 @@ static const struct page_operations anon_ops = {
 	.type = VM_ANON,
 };
 
+/* Project 3 : Swapping in & out */
+/* SECTOR_PER_PAGE = PGSIZE(4096bytes) / DISK_SECTOR_SIZE(512bytes) => 8 SECTOR */
+struct bitmap *swap_table;
+const size_t SECTOR_PER_PAGE = (PGSIZE / DISK_SECTOR_SIZE);
+static struct disk *swap_disk;
+
 /* Initialize the data for anonymous pages */
 void vm_anon_init(void)
 {
 	/* TODO: Set up the swap_disk. */
-	swap_disk = NULL;
+	swap_disk = disk_get(1, 1); // swap_disk
+	size_t swap_slot_cnt =  disk_size(swap_disk) / SECTOR_PER_PAGE; 
+
+	swap_table = bitmap_create(swap_slot_cnt);
 }
 
 /* Initialize the file mapping */
@@ -34,7 +46,7 @@ bool anon_initializer(struct page *page, enum vm_type type, void *kva)
 	page->operations = &anon_ops;
 	struct anon_page *anon_page = &page->anon;
 
-	anon_page->test = 4;
+	// anon_page->test = 4;
 
 	return true;
 }
@@ -44,6 +56,24 @@ static bool
 anon_swap_in(struct page *page, void *kva)
 {
 	struct anon_page *anon_page = &page->anon;
+
+	/* page의 swap_slot_number를 불러들임 */
+	size_t swap_slot_idx = anon_page->swap_slot_no;
+	
+	/* 해당 swap_slot이 false인지 확인*/
+	if (bitmap_test(swap_table, swap_slot_idx) == false){
+		return false;
+	}
+
+	/* disk -> kva로 페이지에 대한 내용을 써줌 */
+	for(int i = 0; i < SECTOR_PER_PAGE; i++){
+		disk_read(swap_disk, swap_slot_idx * SECTOR_PER_PAGE + i, kva + (DISK_SECTOR_SIZE * i));}
+
+	/* bitmap 및 pml4에 대한 내용을 갱신*/
+	bitmap_set(swap_table, swap_slot_idx, false);
+	// pml4_set_page(thread_current()->pml4, page->va, kva, page->writable);
+
+	return true;
 }
 
 /* Swap out the page by writing contents to the swap disk. */
@@ -51,6 +81,25 @@ static bool
 anon_swap_out(struct page *page)
 {
 	struct anon_page *anon_page = &page->anon;
+	
+	/* swap table에서 swap_slot_idx를 찾아서 반환*/
+	size_t swap_slot_idx = bitmap_scan(swap_table, 0, 1, false);
+	if (swap_slot_idx == BITMAP_ERROR)
+		return false;
+	
+	/* SECTOR_PER_PAGE 개의 섹터에 페이지에 대한 내용을 써줌 */
+	for(int i = 0; i < SECTOR_PER_PAGE; i++){
+		disk_write(swap_disk, swap_slot_idx * SECTOR_PER_PAGE + i, page->va + (DISK_SECTOR_SIZE * i));}
+
+	/* 해당 swap_slot에 대한 비트를 true로 변경 후 pml4_clear_page */
+	bitmap_set(swap_table, swap_slot_idx, true);
+	pml4_clear_page(thread_current()->pml4, page->va);
+	
+
+	/* page swap_slot_number에 swap_slot_idx를 저장 */
+	anon_page->swap_slot_no = swap_slot_idx;
+
+	return true;
 }
 
 /* Destroy the anonymous page. PAGE will be freed by the caller. */

--- a/vm/file.c
+++ b/vm/file.c
@@ -153,7 +153,7 @@ void do_munmap(void *addr)
 		file_info = page->uninit.aux;   // ??? 이 코드를 제대로 모르겠음 (왜 aux가 file_info 인건지)
 		size_t ofs = file_info -> ofs;
 		
-		if ((pml4_is_dirty(curr->pml4, page->va)) && (file_info->page_read_bytes == PGSIZE)){
+		if ((pml4_is_dirty(curr->pml4, page->va))){
 
 			file_write_at(mmap_file->file, page->va, file_info->page_read_bytes, ofs);
 			pml4_set_dirty(curr->pml4, page->va, 0);

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -131,6 +131,8 @@ vm_evict_frame(void)
 {
 	struct frame *victim UNUSED = vm_get_victim();
 	/* TODO: swap out the victim and return the evicted frame. */
+	
+
 
 	return NULL;
 }
@@ -146,7 +148,7 @@ vm_get_frame(void)
 
 	frame->kva = palloc_get_page(PAL_USER);
 	if (frame->kva == NULL)
-		PANIC("TO DO");
+		frame = vm_evict_frame();
 
 	frame->page = NULL;
 


### PR DESCRIPTION
### mmap-over 문제 (12.09 오후)
<img width="450" alt="image" src="https://user-images.githubusercontent.com/96214306/206747419-07402f69-f868-4267-a56f-1a388e741b73.png">

- mmap에서 포인터 활용이 잘못되어서 제대로 예외처리를 못해주고 있었음 
- 내일 2개만 더 잡고 swap in & swap out 들어가면 될 듯!!

---

### mmap-exit, write가 다시 떠오른 이유? (12.10 오전)
<img width="600" alt="image" src ="https://user-images.githubusercontent.com/96214306/206823165-6b469501-1112-47bb-ac2f-cfdf58956687.png">

<img width="600" alt="image" src="https://user-images.githubusercontent.com/96214306/206822967-9acb65b2-aa8f-4072-a5f5-257bfbfbef2c.png">

- 위의 깃북내용을 참고해서 munmap할 때 PGSIZE에 맞지 않는 뒤의 자료들을 처리해주는 작업을 하려고 했으나, 
  작업을 수행하지 않는 것이 맞다고 판단됨 
    - (의문) 뒤에 0으로 처리된 값은 자동으로 버려지는 것인지?

---

### 현재상황
FAIL tests/vm/page-merge-par
FAIL tests/vm/page-merge-stk
FAIL tests/vm/page-merge-mm
FAIL tests/vm/swap-file
FAIL tests/vm/swap-anon
FAIL tests/vm/swap-iter
FAIL tests/vm/swap-fork
FAIL tests/vm/cow/cow-simple
8 of 141 tests failed.

위와 같은 상황